### PR TITLE
feat: add split pdf ranges tool flow (ashreevyshnavi/127/split-pdf-ra…

### DIFF
--- a/src/app/(tools)/split/page.tsx
+++ b/src/app/(tools)/split/page.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { z } from "zod";
+
+import PresignedUploader from "@/components/upload/PresignedUploader";
+import { createSplitPdfRangesJob } from "@/lib/api/client";
+import { splitPdfRangesSchema } from "@/lib/splitPdfRanges";
+import type { UploadedFileResult } from "@/lib/upload/s3Put";
+import { useJobPoll } from "@/hooks/useJobPoll";
+
+const splitFormSchema = z.object({
+  inputKey: z.string().trim().min(1, "Upload a PDF before starting."),
+  ranges: splitPdfRangesSchema,
+});
+
+function getUiStatusLabel(
+  status: "pending" | "processing" | "done" | "failed" | "canceled"
+) {
+  switch (status) {
+    case "pending":
+      return "Queued";
+    case "processing":
+      return "Processing";
+    case "done":
+      return "Done";
+    case "failed":
+      return "Failed";
+    case "canceled":
+      return "Canceled";
+  }
+}
+
+export default function SplitPdfPage() {
+  const [uploadedFile, setUploadedFile] = useState<UploadedFileResult | null>(
+    null
+  );
+  const [ranges, setRanges] = useState("");
+  const [rangeTouched, setRangeTouched] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [activeJobId, setActiveJobId] = useState<string | null>(null);
+  const [initialStatus, setInitialStatus] = useState<
+    "pending" | "processing" | "done" | "failed" | "canceled" | null
+  >(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const formResult = useMemo(
+    () =>
+      splitFormSchema.safeParse({
+        inputKey: uploadedFile?.objectKey ?? "",
+        ranges,
+      }),
+    [ranges, uploadedFile]
+  );
+
+  const rangeIssue = formResult.success
+    ? null
+    : formResult.error.issues.find((issue) => issue.path[0] === "ranges")
+        ?.message ?? null;
+  const uploadIssue = formResult.success
+    ? null
+    : formResult.error.issues.find((issue) => issue.path[0] === "inputKey")
+        ?.message ?? null;
+
+  const { data, error, isLoading, isPaused, isPolling } = useJobPoll(
+    activeJobId,
+    {
+      enabled: Boolean(activeJobId),
+    }
+  );
+
+  const currentStatus = data?.status ?? initialStatus;
+  const failureMessage =
+    data?.status === "failed"
+      ? data.errorMessage || data.errorCode || "The split job failed."
+      : error;
+
+  const handleUploadComplete = (completed: UploadedFileResult[]) => {
+    setUploadedFile(completed[0] ?? null);
+    setSubmitError(null);
+    setActiveJobId(null);
+    setInitialStatus(null);
+  };
+
+  const handleSubmit = async () => {
+    setRangeTouched(true);
+    setSubmitError(null);
+    setActiveJobId(null);
+    setInitialStatus(null);
+
+    if (!formResult.success || !uploadedFile) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const response = await createSplitPdfRangesJob({
+        inputKey: uploadedFile.objectKey,
+        ranges: formResult.data.ranges,
+      });
+
+      setInitialStatus(response.status);
+      setActiveJobId(response.jobId);
+    } catch (caughtError) {
+      setSubmitError(
+        caughtError instanceof Error && caughtError.message.trim()
+          ? caughtError.message
+          : "Unable to start the split job."
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="space-y-8" id="main-content">
+      <section className="rounded-[2rem] border border-white/70 bg-white/85 p-8 shadow-[0_30px_80px_rgba(15,23,42,0.12)] backdrop-blur">
+        <div className="space-y-4">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-signal">
+            Split PDF
+          </p>
+          <h1 className="text-4xl font-black tracking-tight text-ink sm:text-5xl">
+            Split one PDF into the page ranges you need.
+          </h1>
+          <p className="max-w-3xl text-base leading-7 text-slate-600">
+            Upload a single PDF, enter page ranges like 1-3,5,8-10, then track
+            the split job until the download is ready.
+          </p>
+        </div>
+      </section>
+
+      <PresignedUploader
+        allowMultiple={false}
+        buttonLabel="Select PDF"
+        description="This public tool keeps the first split workflow simple: one source PDF, one ranges field, and a clear handoff into background processing."
+        helperText="Upload one PDF, wait for verification, then start the split job."
+        onComplete={handleUploadComplete}
+        title="Upload the PDF you want to split."
+      />
+
+      <section className="rounded-[2rem] border border-white/70 bg-white/90 p-8 shadow-[0_24px_60px_rgba(15,23,42,0.08)] backdrop-blur">
+        <div className="space-y-6">
+          <div className="space-y-2">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">
+              Split options
+            </p>
+            <h2 className="text-3xl font-black tracking-tight text-ink">
+              Choose the page ranges to keep.
+            </h2>
+            <p className="max-w-2xl text-sm leading-7 text-slate-600">
+              Use comma-separated ranges like 1-3,5,8-10. The tool validates the
+              pattern before creating a job.
+            </p>
+          </div>
+
+          <div className="grid gap-5 lg:grid-cols-[1.15fr_0.85fr]">
+            <div className="space-y-4 rounded-[1.5rem] border border-dashed border-slate-300 bg-mist/80 p-5">
+              <label className="block text-sm font-semibold text-slate-700">
+                Page ranges
+                <input
+                  className="mt-3 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-ink outline-none transition focus:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-signal"
+                  onBlur={() => setRangeTouched(true)}
+                  onChange={(event) => setRanges(event.target.value)}
+                  placeholder="1-3,5,8-10"
+                  type="text"
+                  value={ranges}
+                />
+              </label>
+
+              {rangeTouched && rangeIssue ? (
+                <p
+                  aria-live="polite"
+                  className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+                  role="status"
+                >
+                  {rangeIssue}
+                </p>
+              ) : null}
+
+              {!uploadedFile && uploadIssue ? (
+                <p
+                  aria-live="polite"
+                  className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+                  role="status"
+                >
+                  {uploadIssue}
+                </p>
+              ) : null}
+
+              {submitError ? (
+                <p
+                  aria-live="polite"
+                  className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900"
+                  role="status"
+                >
+                  {submitError}
+                </p>
+              ) : null}
+
+              <button
+                className="inline-flex rounded-full bg-ink px-5 py-3 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-slate-900 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={!formResult.success || isSubmitting}
+                onClick={handleSubmit}
+                type="button"
+              >
+                {isSubmitting ? "Starting split..." : "Start split job"}
+              </button>
+            </div>
+
+            <aside className="rounded-[1.5rem] border border-slate-200 bg-white px-5 py-4 shadow-sm">
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Current input
+              </p>
+              <div className="mt-4 space-y-3 text-sm text-slate-700">
+                <div className="rounded-2xl bg-mist px-4 py-3">
+                  <p className="font-semibold text-slate-500">Uploaded file</p>
+                  <p className="mt-1 text-base font-medium text-ink">
+                    {uploadedFile?.filename ?? "No PDF uploaded yet"}
+                  </p>
+                </div>
+                <div className="rounded-2xl bg-mist px-4 py-3">
+                  <p className="font-semibold text-slate-500">Ranges</p>
+                  <p className="mt-1 text-base font-medium text-ink">
+                    {ranges.trim() || "No ranges entered yet"}
+                  </p>
+                </div>
+              </div>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-[2rem] border border-white/70 bg-white/90 p-8 shadow-[0_24px_60px_rgba(15,23,42,0.08)] backdrop-blur">
+        <div className="space-y-6">
+          <div className="space-y-2">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">
+              Job progress
+            </p>
+            <h2 className="text-3xl font-black tracking-tight text-ink">
+              Watch the split job move from queue to download.
+            </h2>
+          </div>
+
+          <div className="rounded-[1.5rem] border border-slate-200 bg-white px-5 py-4 shadow-sm">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-2">
+                <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Active job
+                </p>
+                <p className="text-base font-semibold text-ink">
+                  {activeJobId
+                    ? `Watching ${activeJobId}`
+                    : "No split job started yet"}
+                </p>
+                <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-600">
+                  <span className="rounded-full bg-slate-100 px-3 py-1">
+                    {isLoading ? "Request in flight" : "Idle"}
+                  </span>
+                  <span className="rounded-full bg-slate-100 px-3 py-1">
+                    {isPolling
+                      ? "Polling active"
+                      : isPaused
+                        ? "Polling paused"
+                        : "Polling stopped"}
+                  </span>
+                </div>
+              </div>
+
+              {currentStatus ? (
+                <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-600">
+                  {getUiStatusLabel(currentStatus)}
+                </span>
+              ) : null}
+            </div>
+
+            {failureMessage ? (
+              <p
+                aria-live="polite"
+                className="mt-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900"
+                role="status"
+              >
+                {failureMessage}
+              </p>
+            ) : null}
+
+            {data?.status === "done" ? (
+              <div className="mt-4 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-4 text-sm text-emerald-900">
+                <p className="font-semibold">Your split PDF is ready.</p>
+                <a
+                  className="mt-3 inline-flex rounded-full bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-700"
+                  href={data.downloadUrl}
+                >
+                  Download split PDF
+                </a>
+              </div>
+            ) : (
+              <p className="mt-4 text-sm leading-7 text-slate-600">
+                {currentStatus
+                  ? "This panel updates automatically while the split job runs."
+                  : "Upload a PDF and start a split job to see progress here."}
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(tools)/tools/page.tsx
+++ b/src/app/(tools)/tools/page.tsx
@@ -22,9 +22,10 @@ const toolCards: ToolCard[] = [
   {
     category: "Document transforms",
     description:
-      "Upcoming PDF processing entry points will appear here as dedicated tool pages land.",
-    name: "Merge and Organize PDFs",
-    status: "planned",
+      "Public split workflow for one uploaded PDF, a typed ranges field, and background job progress.",
+    href: "/split",
+    name: "Split PDF by Ranges",
+    status: "shipped",
   },
   {
     category: "Extraction",

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -1,0 +1,223 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { z } from "zod";
+
+import { toErrorResponse } from "@/app/api/_utils/http";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import {
+  ConflictError,
+  InternalAppError,
+  NotFoundError,
+  ValidationError,
+} from "@/lib/errors";
+import {
+  GUEST_ID_COOKIE,
+  INTERNAL_GUEST_ID_HEADER,
+  INTERNAL_GUEST_ID_TRUST_HEADER,
+  isGuestId,
+  verifyGuestCookieValue,
+} from "@/lib/guest";
+import { createLogger } from "@/lib/logger";
+import { enqueuePdfJob, type PdfJobType } from "@/lib/queue";
+import { normalizeRequestId, REQUEST_ID_HEADER } from "@/lib/request-id";
+import { splitPdfRangesSchema } from "@/lib/splitPdfRanges";
+
+const FILE_OBJECT_READY = "READY";
+const SUPPORTED_JOB_TYPE = "split_pdf_ranges" satisfies PdfJobType;
+
+const createJobBodySchema = z.object({
+  inputKeys: z.array(z.string().trim().min(1)).length(1),
+  jobType: z.literal(SUPPORTED_JOB_TYPE),
+  options: z.object({
+    ranges: splitPdfRangesSchema,
+  }),
+});
+
+function canAccessFile(
+  file: { guestId: string | null; userId: string | null },
+  access: { guestId?: string; userId?: string }
+) {
+  const isAuthorizedUser = Boolean(
+    access.userId && file.userId === access.userId
+  );
+  const isAuthorizedGuest = Boolean(
+    !file.userId &&
+      access.guestId &&
+      file.guestId &&
+      access.guestId === file.guestId
+  );
+
+  return isAuthorizedUser || isAuthorizedGuest;
+}
+
+async function parseCreateJobBody(request: NextRequest) {
+  try {
+    return createJobBodySchema.parse(await request.json());
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const issue = error.issues[0];
+      throw new ValidationError(issue?.message || "Invalid job request", {
+        code: "INVALID_JOB_REQUEST",
+      });
+    }
+
+    throw error;
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const requestId = normalizeRequestId(request.headers.get(REQUEST_ID_HEADER));
+  const session = await auth();
+  const userId = session?.user?.id;
+  const forwardedGuestId = request.headers
+    .get(INTERNAL_GUEST_ID_HEADER)
+    ?.trim();
+  const trustedGuestHeader =
+    request.headers.get(INTERNAL_GUEST_ID_TRUST_HEADER) === "1";
+  const trustedGuestId =
+    trustedGuestHeader && forwardedGuestId && isGuestId(forwardedGuestId)
+      ? forwardedGuestId
+      : null;
+  const guestId = userId
+    ? undefined
+    : trustedGuestId ||
+      (await verifyGuestCookieValue(request.cookies.get(GUEST_ID_COOKIE)?.value)) ||
+      undefined;
+  const log = createLogger({
+    requestId,
+    userId,
+  });
+
+  try {
+    const body = await parseCreateJobBody(request);
+    const [inputKey] = body.inputKeys;
+    const file = await prisma.fileObject.findUnique({
+      where: {
+        objectKey: inputKey,
+      },
+      select: {
+        guestId: true,
+        id: true,
+        mimeType: true,
+        objectKey: true,
+        status: true,
+        userId: true,
+      },
+    });
+
+    if (!file || !canAccessFile(file, { guestId, userId })) {
+      return toErrorResponse(
+        new NotFoundError("File not found", { code: "FILE_NOT_FOUND" }),
+        {
+          cacheControl: "no-store",
+        }
+      );
+    }
+
+    if (file.status !== FILE_OBJECT_READY) {
+      return toErrorResponse(
+        new ConflictError("Uploaded file is not ready yet", {
+          code: "FILE_NOT_READY",
+          httpStatus: 409,
+        }),
+        {
+          cacheControl: "no-store",
+        }
+      );
+    }
+
+    if (file.mimeType !== "application/pdf") {
+      return toErrorResponse(
+        new ValidationError("Only PDF files can be split.", {
+          code: "FILE_INVALID_TYPE",
+        }),
+        {
+          cacheControl: "no-store",
+        }
+      );
+    }
+
+    const job = await prisma.job.create({
+      data: {
+        fileObjectId: file.id,
+        guestId: guestId ?? null,
+        inputRef: file.objectKey,
+        type: body.jobType,
+        userId: userId ?? null,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    try {
+      await enqueuePdfJob({
+        inputKey: file.objectKey,
+        jobId: job.id,
+        options: {
+          ranges: body.options.ranges,
+        },
+        requestId,
+        type: body.jobType,
+      });
+    } catch (error) {
+      await prisma.job.update({
+        where: {
+          id: job.id,
+        },
+        data: {
+          completedAt: new Date(),
+          errorCode: "JOB_ENQUEUE_FAILED",
+          errorMessage: "Unable to start the split job.",
+          status: "FAILED",
+        },
+      });
+
+      throw error;
+    }
+
+    log.info(
+      {
+        fileId: file.id,
+        guestId,
+        jobId: job.id,
+        jobType: body.jobType,
+      },
+      "Created PDF tool job"
+    );
+
+    return NextResponse.json(
+      {
+        jobId: job.id,
+        status: "pending",
+      },
+      {
+        status: 201,
+      }
+    );
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return toErrorResponse(error, {
+        cacheControl: "no-store",
+      });
+    }
+
+    log.error(
+      {
+        err: error,
+        guestId,
+      },
+      "Failed to create PDF tool job"
+    );
+
+    return toErrorResponse(
+      new InternalAppError("Unable to create PDF job", {
+        code: "JOB_CREATE_FAILED",
+      }),
+      {
+        cacheControl: "no-store",
+      }
+    );
+  }
+}

--- a/src/components/upload/PresignedUploader.tsx
+++ b/src/components/upload/PresignedUploader.tsx
@@ -14,7 +14,13 @@ import {
 } from "@/lib/upload/s3Put";
 
 type PresignedUploaderProps = {
+  accept?: string;
+  allowMultiple?: boolean;
+  buttonLabel?: string;
+  description?: string;
+  helperText?: string;
   onComplete?: (completed: UploadedFileResult[]) => void;
+  title?: string;
 };
 
 function formatBytes(bytes: number) {
@@ -47,11 +53,20 @@ function getStatusLabel(item: UploadItem) {
 }
 
 function isPdf(file: File) {
-  return file.type === "application/pdf";
+  return (
+    file.type === "application/pdf" ||
+    file.name.trim().toLowerCase().endsWith(".pdf")
+  );
 }
 
 export default function PresignedUploader({
+  accept = "application/pdf,.pdf",
+  allowMultiple = true,
+  buttonLabel = "Select PDFs",
+  description = "Files upload sequentially so progress, cancelation, and verification stay predictable in the first release.",
+  helperText = "Uploads run one file at a time and return verified file IDs.",
   onComplete,
+  title = "Upload large PDFs with visible progress.",
 }: PresignedUploaderProps) {
   const [itemsById, setItemsById] = useState<Record<string, UploadItem>>({});
   const [itemOrder, setItemOrder] = useState<string[]>([]);
@@ -125,6 +140,11 @@ export default function PresignedUploader({
       return;
     }
 
+    if (!allowMultiple && selectedFiles.length > 1) {
+      setSelectionError("Choose a single PDF file to continue.");
+      return;
+    }
+
     const validFiles = selectedFiles.filter(isPdf);
 
     if (!validFiles.length || validFiles.length !== selectedFiles.length) {
@@ -179,11 +199,10 @@ export default function PresignedUploader({
           </p>
           <div className="space-y-2">
             <h2 className="text-3xl font-black tracking-tight text-ink">
-              Upload large PDFs with visible progress.
+              {title}
             </h2>
             <p className="max-w-2xl text-sm leading-7 text-slate-600">
-              Files upload sequentially so progress, cancelation, and verification
-              stay predictable in the first release.
+              {description}
             </p>
           </div>
         </div>
@@ -192,20 +211,22 @@ export default function PresignedUploader({
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-base font-semibold text-ink">
-                Choose one or more PDF files
+                {allowMultiple
+                  ? "Choose one or more PDF files"
+                  : "Choose a PDF file"}
               </p>
               <p className="mt-1 text-sm text-slate-600">
-                Uploads run one file at a time and return verified file IDs.
+                {helperText}
               </p>
             </div>
 
             <label className="inline-flex cursor-pointer items-center justify-center rounded-full bg-ink px-5 py-3 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-slate-900">
-              <span>{isUploading ? "Uploading..." : "Select PDFs"}</span>
+              <span>{isUploading ? "Uploading..." : buttonLabel}</span>
               <input
-                accept="application/pdf,.pdf"
+                accept={accept}
                 className="sr-only"
                 disabled={isUploading}
-                multiple
+                multiple={allowMultiple}
                 onChange={handleSelection}
                 type="file"
               />

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { splitPdfRangesSchema } from "@/lib/splitPdfRanges";
+import type { JobErrorResponse, JobStatusResponse } from "@/types/job";
+
+export class ApiClientError extends Error {
+  code: string;
+  status: number;
+
+  constructor(message: string, options: { code: string; status: number }) {
+    super(message);
+    this.name = "ApiClientError";
+    this.code = options.code;
+    this.status = options.status;
+  }
+}
+
+export type PresignUploadResponse = {
+  fileId: string;
+  headers?: Record<string, string>;
+  objectKey: string;
+  uploadUrl: string;
+};
+
+export type CompleteUploadResponse = {
+  ok?: boolean;
+  retryable?: boolean;
+};
+
+export type CreateJobResponse = {
+  jobId: string;
+  status: JobStatusResponse["status"];
+};
+
+async function parseJsonSafe<T>(response: Response): Promise<T | null> {
+  try {
+    return (await response.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function requestJson<T>(
+  input: string,
+  init?: RequestInit
+): Promise<T> {
+  const response = await fetch(input, init);
+  const payload = await parseJsonSafe<T & JobErrorResponse>(response);
+
+  if (!response.ok) {
+    throw new ApiClientError(
+      payload?.error?.message || payload?.error?.code || "Request failed",
+      {
+        code: payload?.error?.code || "REQUEST_FAILED",
+        status: response.status,
+      }
+    );
+  }
+
+  if (!payload) {
+    throw new ApiClientError("Request failed", {
+      code: "INVALID_RESPONSE",
+      status: response.status,
+    });
+  }
+
+  return payload;
+}
+
+export async function createSplitPdfRangesJob(input: {
+  inputKey: string;
+  ranges: string;
+}) {
+  const ranges = splitPdfRangesSchema.parse(input.ranges);
+
+  return requestJson<CreateJobResponse>("/api/jobs", {
+    body: JSON.stringify({
+      inputKeys: [input.inputKey],
+      jobType: "split_pdf_ranges",
+      options: {
+        ranges,
+      },
+    }),
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+}

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -9,7 +9,7 @@ import { normalizeRequestId } from "@/lib/request-id";
 const queueEnv = getQueueEnv();
 
 export const PDF_QUEUE_NAME = "pdf-jobs";
-export const PDF_JOB_TYPES = ["process"] as const;
+export const PDF_JOB_TYPES = ["process", "split_pdf_ranges"] as const;
 const PDF_JOB_TYPE_SET = new Set<string>(PDF_JOB_TYPES);
 export const CLEANUP_QUEUE_NAME = "cleanup-jobs";
 export const CLEANUP_JOB_NAME = "delete-expired-file-objects";
@@ -17,7 +17,11 @@ export const CLEANUP_JOB_NAME = "delete-expired-file-objects";
 export type PdfJobType = (typeof PDF_JOB_TYPES)[number];
 
 export type PdfJobPayload = {
+  inputKey?: string;
   jobId: string;
+  options?: {
+    ranges?: string;
+  };
   requestId?: string;
   type: PdfJobType;
 };
@@ -94,7 +98,13 @@ export function getDefaultPdfJobOptions(): JobsOptions {
 export function normalizePdfJobPayload(payload: PdfJobPayload): PdfJobPayload {
   const normalizedRequestId = normalizeRequestId(payload.requestId);
   const normalizedPayload = {
+    inputKey: payload.inputKey?.trim() || undefined,
     jobId: payload.jobId.trim(),
+    options: payload.options?.ranges
+      ? {
+          ranges: payload.options.ranges.trim(),
+        }
+      : undefined,
     requestId: normalizedRequestId ? normalizedRequestId : undefined,
     type: payload.type,
   } satisfies PdfJobPayload;
@@ -105,6 +115,15 @@ export function normalizePdfJobPayload(payload: PdfJobPayload): PdfJobPayload {
 
   if (!PDF_JOB_TYPE_SET.has(normalizedPayload.type)) {
     throw new Error(`Unsupported PDF job type: ${normalizedPayload.type}`);
+  }
+
+  if (
+    normalizedPayload.type === "split_pdf_ranges" &&
+    (!normalizedPayload.inputKey || !normalizedPayload.options?.ranges)
+  ) {
+    throw new Error(
+      "split_pdf_ranges jobs require both inputKey and options.ranges"
+    );
   }
 
   return normalizedPayload;

--- a/src/lib/splitPdfRanges.ts
+++ b/src/lib/splitPdfRanges.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+const rangeTokenPattern = /^\d+(?:\s*-\s*\d+)?$/;
+
+function hasValidRangeSyntax(value: string) {
+  const segments = value
+    .split(",")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  if (!segments.length) {
+    return false;
+  }
+
+  return segments.every((segment) => {
+    if (!rangeTokenPattern.test(segment)) {
+      return false;
+    }
+
+    const [startValue, endValue] = segment.split("-").map((part) => part.trim());
+    const start = Number.parseInt(startValue, 10);
+    const end = endValue ? Number.parseInt(endValue, 10) : start;
+
+    return (
+      Number.isInteger(start) &&
+      Number.isInteger(end) &&
+      start > 0 &&
+      end > 0 &&
+      start <= end
+    );
+  });
+}
+
+export const splitPdfRangesSchema = z
+  .string()
+  .trim()
+  .min(1, "Enter at least one page range.")
+  .refine(hasValidRangeSyntax, {
+    message: "Use page ranges like 1-3,5,8-10.",
+  });

--- a/src/lib/upload/s3Put.ts
+++ b/src/lib/upload/s3Put.ts
@@ -1,5 +1,12 @@
 "use client";
 
+import {
+  ApiClientError,
+  requestJson,
+  type CompleteUploadResponse,
+  type PresignUploadResponse,
+} from "@/lib/api/client";
+
 export type UploadStatus =
   | "queued"
   | "presigning"
@@ -23,27 +30,15 @@ export type UploadedFileResult = {
   etag: string;
   fileId: string;
   filename: string;
+  objectKey: string;
 };
 
 type PresignResponse = {
-  error?: {
-    code: string;
-    message: string;
-  };
   fileId: string;
   headers?: Record<string, string>;
+  objectKey: string;
   uploadUrl: string;
 };
-
-type CompleteResponse = {
-  error?: {
-    code: string;
-    message: string;
-  };
-  retryable?: boolean;
-};
-
-type FetchLike = typeof fetch;
 
 type XhrLike = Pick<
   XMLHttpRequest,
@@ -71,7 +66,14 @@ type UploadCallbacks = {
 };
 
 type UploadRuntime = UploadCallbacks & {
-  fetchImpl?: FetchLike;
+  completeUploadRequest?: (
+    fileId: string,
+    etag: string
+  ) => Promise<CompleteUploadResponse>;
+  createPresignedUploadRequest?: (
+    file: File
+  ) => Promise<PresignUploadResponse>;
+  fetchImpl?: typeof fetch;
   sleep?: (ms: number) => Promise<void>;
   xhrFactory?: () => XhrLike;
 };
@@ -113,19 +115,37 @@ function normalizeEtag(etag: string) {
   return etag.trim().replace(/^"+|"+$/g, "");
 }
 
-async function parseJsonSafe<T>(response: Response): Promise<T | null> {
-  try {
-    return (await response.json()) as T;
-  } catch {
-    return null;
-  }
+function createPresignedUpload(file: File) {
+  return requestJson<PresignUploadResponse>("/api/upload/presign", {
+    body: JSON.stringify({
+      contentType: file.type || "application/pdf",
+      filename: file.name,
+      sizeBytes: file.size,
+    }),
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
 }
 
-async function presignFile(
+function completePresignedUpload(fileId: string, etag: string) {
+  return requestJson<CompleteUploadResponse>("/api/upload/complete", {
+    body: JSON.stringify({
+      etag,
+      fileId,
+    }),
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+}
+
+async function createPresignedUploadWithFetch(
   file: File,
-  fetchImpl: FetchLike,
-  signal: AbortSignal
-): Promise<PresignResponse> {
+  fetchImpl: typeof fetch
+) {
   const response = await fetchImpl("/api/upload/presign", {
     body: JSON.stringify({
       contentType: file.type || "application/pdf",
@@ -136,12 +156,18 @@ async function presignFile(
       "content-type": "application/json",
     },
     method: "POST",
-    signal,
   });
 
-  const payload = await parseJsonSafe<PresignResponse>(response);
+  const payload = (await response.json()) as
+    | (PresignUploadResponse & {
+        error?: {
+          code: string;
+          message: string;
+        };
+      })
+    | null;
 
-  if (!response.ok || !payload?.fileId || !payload.uploadUrl) {
+  if (!response.ok || !payload?.fileId || !payload.uploadUrl || !payload.objectKey) {
     throw new Error(
       payload?.error?.message ||
         payload?.error?.code ||
@@ -149,9 +175,63 @@ async function presignFile(
     );
   }
 
+  return payload;
+}
+
+async function completePresignedUploadWithFetch(
+  fileId: string,
+  etag: string,
+  fetchImpl: typeof fetch
+) {
+  const response = await fetchImpl("/api/upload/complete", {
+    body: JSON.stringify({
+      etag,
+      fileId,
+    }),
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+  const payload = (await response.json()) as
+    | ({
+        error?: {
+          code: string;
+          message: string;
+        };
+      } & CompleteUploadResponse)
+    | null;
+
+  if (!response.ok) {
+    const retryableError = new Error(
+      payload?.error?.message ||
+        payload?.error?.code ||
+        "Unable to verify upload"
+    ) as Error & { retryable?: boolean };
+    retryableError.retryable = Boolean(payload?.retryable);
+    throw retryableError;
+  }
+
+  return payload ?? {};
+}
+
+async function presignFile(
+  file: File,
+  createPresignedUploadRequest: (
+    file: File
+  ) => Promise<PresignUploadResponse>,
+  signal: AbortSignal
+): Promise<PresignResponse> {
+  if (signal.aborted) {
+    throw new DOMException("Upload canceled", "AbortError");
+  }
+
+  const payload = await createPresignedUploadRequest(file);
+
   return {
     fileId: payload.fileId,
     headers: payload.headers,
+    objectKey: payload.objectKey,
     uploadUrl: payload.uploadUrl,
   };
 }
@@ -228,43 +308,47 @@ function putObjectWithProgress(
 async function completeUpload(
   fileId: string,
   etag: string,
-  fetchImpl: FetchLike,
+  completeUploadRequest: (
+    fileId: string,
+    etag: string
+  ) => Promise<CompleteUploadResponse>,
   signal: AbortSignal
 ) {
-  const response = await fetchImpl("/api/upload/complete", {
-    body: JSON.stringify({
-      etag: normalizeEtag(etag),
-      fileId,
-    }),
-    headers: {
-      "content-type": "application/json",
-    },
-    method: "POST",
-    signal,
-  });
+  if (signal.aborted) {
+    throw new DOMException("Upload canceled", "AbortError");
+  }
 
-  const payload = await parseJsonSafe<CompleteResponse>(response);
+  try {
+    await completeUploadRequest(fileId, normalizeEtag(etag));
+  } catch (error) {
+    if (error instanceof ApiClientError) {
+      const retryableError = new Error(error.message) as Error & {
+        retryable?: boolean;
+      };
+      retryableError.retryable = false;
+      throw retryableError;
+    }
 
-  if (!response.ok) {
-    const message =
-      payload?.error?.message ||
-      payload?.error?.code ||
-      "Unable to verify upload";
-    const error = new Error(message) as Error & { retryable?: boolean };
-    error.retryable = Boolean(payload?.retryable);
-    throw error;
+    if (error instanceof Error) {
+      throw error;
+    }
+
+    throw new Error("Unable to verify upload");
   }
 }
 
 async function completeWithRetry(
   fileId: string,
   etag: string,
-  fetchImpl: FetchLike,
+  completeUploadRequest: (
+    fileId: string,
+    etag: string
+  ) => Promise<CompleteUploadResponse>,
   signal: AbortSignal,
   sleep: (ms: number) => Promise<void>
 ) {
   try {
-    await completeUpload(fileId, etag, fetchImpl, signal);
+    await completeUpload(fileId, etag, completeUploadRequest, signal);
   } catch (error) {
     const retryable =
       typeof error === "object" &&
@@ -282,7 +366,7 @@ async function completeWithRetry(
       throw new DOMException("Upload canceled", "AbortError");
     }
 
-    await completeUpload(fileId, etag, fetchImpl, signal);
+    await completeUpload(fileId, etag, completeUploadRequest, signal);
   }
 }
 
@@ -290,7 +374,17 @@ export function startPresignedUploads(
   files: File[],
   runtime: UploadRuntime = {}
 ): UploadController {
-  const fetchImpl = runtime.fetchImpl ?? fetch;
+  const createPresignedUploadRequest =
+    runtime.createPresignedUploadRequest ??
+    (runtime.fetchImpl
+      ? (file: File) => createPresignedUploadWithFetch(file, runtime.fetchImpl!)
+      : createPresignedUpload);
+  const completeUploadRequest =
+    runtime.completeUploadRequest ??
+    (runtime.fetchImpl
+      ? (fileId: string, etag: string) =>
+          completePresignedUploadWithFetch(fileId, etag, runtime.fetchImpl!)
+      : completePresignedUpload);
   const xhrFactory = runtime.xhrFactory ?? (() => new XMLHttpRequest());
   const sleep =
     runtime.sleep ??
@@ -326,7 +420,11 @@ export function startPresignedUploads(
         item.error = undefined;
         emit(item);
 
-        const presigned = await presignFile(item.file, fetchImpl, controller.signal);
+        const presigned = await presignFile(
+          item.file,
+          createPresignedUploadRequest,
+          controller.signal
+        );
 
         item.fileId = presigned.fileId;
 
@@ -357,7 +455,7 @@ export function startPresignedUploads(
         await completeWithRetry(
           presigned.fileId,
           uploaded.etag,
-          fetchImpl,
+          completeUploadRequest,
           controller.signal,
           sleep
         );
@@ -369,12 +467,10 @@ export function startPresignedUploads(
           etag: uploaded.etag,
           fileId: presigned.fileId,
           filename: item.file.name,
+          objectKey: presigned.objectKey,
         });
       } catch (error) {
-        if (
-          error instanceof DOMException &&
-          error.name === "AbortError"
-        ) {
+        if (error instanceof DOMException && error.name === "AbortError") {
           item.status = "canceled";
           item.error = undefined;
           emit(item);

--- a/src/server/jobs/jobAccess.ts
+++ b/src/server/jobs/jobAccess.ts
@@ -27,7 +27,7 @@ export type SafeJobProjection =
   | { status: "pending" }
   | { status: "processing" }
   | { downloadUrl: string; status: "done" }
-  | { errorCode?: string; status: "failed" }
+  | { errorCode?: string; errorMessage?: string; status: "failed" }
   | { status: "canceled" };
 
 export function canAccessJob(
@@ -85,6 +85,7 @@ export async function toSafeJobProjection(
     case "FAILED":
       return {
         errorCode: job.errorCode ?? undefined,
+        errorMessage: job.errorMessage ?? undefined,
         status: "failed",
       };
     case "CANCELED":

--- a/src/server/jobs/processPdfJob.ts
+++ b/src/server/jobs/processPdfJob.ts
@@ -68,6 +68,30 @@ export async function processPdfJob(
     );
   }
 
+  if (payload.type === "split_pdf_ranges") {
+    if (!payload.options?.ranges) {
+      throw new ValidationError("Split PDF jobs require page ranges.", {
+        code: "MISSING_SPLIT_RANGES",
+      });
+    }
+
+    if (!payload.inputKey) {
+      throw new ValidationError("Split PDF jobs require an input object key.", {
+        code: "MISSING_SPLIT_INPUT_KEY",
+      });
+    }
+
+    if (dbJob.inputRef && dbJob.inputRef !== payload.inputKey) {
+      throw new ValidationError(
+        `Job "${dbJob.id}" input key does not match the queued payload`,
+        {
+          code: "JOB_INPUT_MISMATCH",
+          httpStatus: 409,
+        }
+      );
+    }
+  }
+
   createLogger({
     jobId: dbJob.id,
     requestId: payload.requestId,
@@ -75,13 +99,15 @@ export async function processPdfJob(
   }).info(
     {
       hasInputRef: Boolean(dbJob.inputRef),
+      ranges: payload.options?.ranges,
       jobType: payload.type,
     },
     "Stub processing PDF job"
   );
 
   const outputKey = buildObjectKey({
-    filename: "processed.pdf",
+    filename:
+      payload.type === "split_pdf_ranges" ? "split-ranges.pdf" : "processed.pdf",
     guestId: dbJob.guestId,
     jobId: dbJob.id,
     kind: "output",

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -13,6 +13,7 @@ export type DoneJobStatus = {
 
 export type FailedJobStatus = {
   errorCode?: string;
+  errorMessage?: string;
   status: "failed";
 };
 

--- a/src/types/pino.d.ts
+++ b/src/types/pino.d.ts
@@ -1,0 +1,23 @@
+declare module "pino" {
+  type Logger = {
+    child: (bindings?: Record<string, unknown>) => Logger;
+    debug: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => void;
+    info: (...args: unknown[]) => void;
+    warn: (...args: unknown[]) => void;
+  };
+
+  type LoggerOptions = {
+    level?: string;
+    redact?: {
+      paths: readonly string[];
+      remove?: boolean;
+    };
+    transport?: {
+      options?: Record<string, unknown>;
+      target: string;
+    };
+  };
+
+  export default function pino(options?: LoggerOptions): Logger;
+}

--- a/tests/download-route.test.ts
+++ b/tests/download-route.test.ts
@@ -46,8 +46,12 @@ jest.mock("next/server", () => ({
 }));
 
 describe("/api/download/[jobId]", () => {
+  const fixedNow = new Date("2026-04-04T12:00:00.000Z");
+
   beforeEach(() => {
     jest.resetModules();
+    jest.useFakeTimers();
+    jest.setSystemTime(fixedNow);
     auth.mockReset();
     findUnique.mockReset();
     createJobEvent.mockReset();
@@ -348,30 +352,23 @@ describe("/api/download/[jobId]", () => {
 
     const { GET } = await import("@/app/api/download/[jobId]/route");
 
-    const originalDateNow = Date.now;
-    Date.now = jest.fn(() => new Date("2026-04-04T12:00:00.000Z").getTime());
-
-    try {
-      const response = await GET(
-        {
-          cookies: {
-            get: jest.fn(),
-          },
-          headers: new Headers(),
-        } as never,
-        { params: { jobId: "job-123" } }
-      );
-
-      expect(response.status).toBe(410);
-      await expect(response.json()).resolves.toEqual({
-        error: {
-          code: "JOB_EXPIRED",
-          message: "Job output has expired",
+    const response = await GET(
+      {
+        cookies: {
+          get: jest.fn(),
         },
-      });
-    } finally {
-      Date.now = originalDateNow;
-    }
+        headers: new Headers(),
+      } as never,
+      { params: { jobId: "job-123" } }
+    );
+
+    expect(response.status).toBe(410);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "JOB_EXPIRED",
+        message: "Job output has expired",
+      },
+    });
   });
 
   it("falls back to a safe filename when the original name is unavailable", async () => {
@@ -510,5 +507,9 @@ describe("/api/download/[jobId]", () => {
         message: "Unable to create download URL",
       },
     });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 });

--- a/tests/job-access.test.ts
+++ b/tests/job-access.test.ts
@@ -141,6 +141,7 @@ describe("job access helpers", () => {
       })
     ).resolves.toEqual({
       errorCode: "WorkerError",
+      errorMessage: "PDF processing failed.",
       status: "failed",
     });
   });

--- a/tests/job-create-route.test.ts
+++ b/tests/job-create-route.test.ts
@@ -1,0 +1,245 @@
+export {};
+
+const auth = jest.fn();
+const findUnique = jest.fn();
+const create = jest.fn();
+const update = jest.fn();
+const enqueuePdfJob = jest.fn();
+const info = jest.fn();
+const error = jest.fn();
+const verifyGuestCookieValue = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json(body: unknown, init?: { status?: number }) {
+      const headers = new Headers();
+
+      return {
+        headers,
+        async json() {
+          return body;
+        },
+        status: init?.status ?? 200,
+      };
+    },
+  },
+}));
+
+describe("/api/jobs", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    auth.mockReset();
+    findUnique.mockReset();
+    create.mockReset();
+    update.mockReset();
+    enqueuePdfJob.mockReset();
+    info.mockReset();
+    error.mockReset();
+    verifyGuestCookieValue.mockReset();
+
+    jest.doMock("@/lib/auth", () => ({ auth }));
+    jest.doMock("@/lib/db", () => ({
+      prisma: {
+        fileObject: {
+          findUnique,
+        },
+        job: {
+          create,
+          update,
+        },
+      },
+    }));
+    jest.doMock("@/lib/queue", () => ({
+      enqueuePdfJob,
+    }));
+    jest.doMock("@/lib/guest", () => ({
+      GUEST_ID_COOKIE: "guestId",
+      INTERNAL_GUEST_ID_HEADER: "x-ulazytools-guest-id",
+      INTERNAL_GUEST_ID_TRUST_HEADER: "x-ulazytools-guest-trusted",
+      isGuestId: (value: string) => /^[0-9a-f-]{36}$/i.test(value),
+      verifyGuestCookieValue: (...args: unknown[]) => verifyGuestCookieValue(...args),
+    }));
+    jest.doMock(
+      "pino",
+      () => {
+        const instance = {
+          child: jest.fn(),
+          error,
+          info,
+        };
+        instance.child.mockReturnValue(instance);
+        const pino = jest.fn(() => instance);
+        return { __esModule: true, default: pino };
+      },
+      { virtual: true }
+    );
+  });
+
+  it("creates and enqueues a split job for the owning authenticated user", async () => {
+    auth.mockResolvedValue({ user: { id: "user-123" } });
+    findUnique.mockResolvedValue({
+      guestId: null,
+      id: "file-123",
+      mimeType: "application/pdf",
+      objectKey: "uploads/2026/04/users/user-123/jobs/file/report.pdf",
+      status: "READY",
+      userId: "user-123",
+    });
+    create.mockResolvedValue({ id: "job-123" });
+    enqueuePdfJob.mockResolvedValue({ id: "job-123" });
+
+    const { POST } = await import("@/app/api/jobs/route");
+
+    const response = await POST({
+      cookies: {
+        get: jest.fn(),
+      },
+      headers: new Headers({
+        "content-type": "application/json",
+        "x-request-id": "req-123",
+      }),
+      json: async () => ({
+        inputKeys: ["uploads/2026/04/users/user-123/jobs/file/report.pdf"],
+        jobType: "split_pdf_ranges",
+        options: {
+          ranges: "1-3,5",
+        },
+      }),
+    } as never);
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      jobId: "job-123",
+      status: "pending",
+    });
+    expect(create).toHaveBeenCalledWith({
+      data: {
+        fileObjectId: "file-123",
+        guestId: null,
+        inputRef: "uploads/2026/04/users/user-123/jobs/file/report.pdf",
+        type: "split_pdf_ranges",
+        userId: "user-123",
+      },
+      select: {
+        id: true,
+      },
+    });
+    expect(enqueuePdfJob).toHaveBeenCalledWith({
+      inputKey: "uploads/2026/04/users/user-123/jobs/file/report.pdf",
+      jobId: "job-123",
+      options: {
+        ranges: "1-3,5",
+      },
+      requestId: "req-123",
+      type: "split_pdf_ranges",
+    });
+  });
+
+  it("returns 409 when the file is not ready", async () => {
+    auth.mockResolvedValue({ user: { id: "user-123" } });
+    findUnique.mockResolvedValue({
+      guestId: null,
+      id: "file-123",
+      mimeType: "application/pdf",
+      objectKey: "uploads/file.pdf",
+      status: "PENDING_UPLOAD",
+      userId: "user-123",
+    });
+
+    const { POST } = await import("@/app/api/jobs/route");
+
+    const response = await POST({
+      cookies: {
+        get: jest.fn(),
+      },
+      headers: new Headers({
+        "content-type": "application/json",
+      }),
+      json: async () => ({
+        inputKeys: ["uploads/file.pdf"],
+        jobType: "split_pdf_ranges",
+        options: {
+          ranges: "1-3",
+        },
+      }),
+    } as never);
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "FILE_NOT_READY",
+        message: "Uploaded file is not ready yet",
+      },
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid ranges", async () => {
+    auth.mockResolvedValue({ user: { id: "user-123" } });
+
+    const { POST } = await import("@/app/api/jobs/route");
+
+    const response = await POST({
+      cookies: {
+        get: jest.fn(),
+      },
+      headers: new Headers({
+        "content-type": "application/json",
+      }),
+      json: async () => ({
+        inputKeys: ["uploads/file.pdf"],
+        jobType: "split_pdf_ranges",
+        options: {
+          ranges: "3-1",
+        },
+      }),
+    } as never);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "INVALID_JOB_REQUEST",
+        message: "Use page ranges like 1-3,5,8-10.",
+      },
+    });
+  });
+
+  it("returns 400 for non-pdf file objects", async () => {
+    auth.mockResolvedValue({ user: { id: "user-123" } });
+    findUnique.mockResolvedValue({
+      guestId: null,
+      id: "file-123",
+      mimeType: "image/png",
+      objectKey: "uploads/file.png",
+      status: "READY",
+      userId: "user-123",
+    });
+
+    const { POST } = await import("@/app/api/jobs/route");
+
+    const response = await POST({
+      cookies: {
+        get: jest.fn(),
+      },
+      headers: new Headers({
+        "content-type": "application/json",
+      }),
+      json: async () => ({
+        inputKeys: ["uploads/file.png"],
+        jobType: "split_pdf_ranges",
+        options: {
+          ranges: "1-3",
+        },
+      }),
+    } as never);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "FILE_INVALID_TYPE",
+        message: "Only PDF files can be split.",
+      },
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/tests/job-status-route.test.ts
+++ b/tests/job-status-route.test.ts
@@ -34,8 +34,12 @@ jest.mock("next/server", () => ({
 }));
 
 describe("/api/jobs/[jobId]", () => {
+  const fixedNow = new Date("2026-04-04T12:00:00.000Z");
+
   beforeEach(() => {
     jest.resetModules();
+    jest.useFakeTimers();
+    jest.setSystemTime(fixedNow);
     auth.mockReset();
     findUnique.mockReset();
     info.mockReset();
@@ -213,6 +217,7 @@ describe("/api/jobs/[jobId]", () => {
 
     await expect(response.json()).resolves.toEqual({
       errorCode: "WorkerError",
+      errorMessage: "PDF processing failed.",
       status: "failed",
     });
   });
@@ -454,31 +459,24 @@ describe("/api/jobs/[jobId]", () => {
 
     const { GET } = await import("@/app/api/jobs/[jobId]/route");
 
-    const originalDateNow = Date.now;
-    Date.now = jest.fn(() => new Date("2026-04-04T12:00:00.000Z").getTime());
-
-    try {
-      const response = await GET(
-        {
-          cookies: {
-            get: jest.fn(),
-          },
-          headers: new Headers(),
-        } as never,
-        { params: { jobId: "job-123" } }
-      );
-
-      expect(response.status).toBe(410);
-      await expect(response.json()).resolves.toEqual({
-        error: {
-          code: "JOB_EXPIRED",
-          message: "Job output has expired",
+    const response = await GET(
+      {
+        cookies: {
+          get: jest.fn(),
         },
-      });
-      expect(response.headers.get("Cache-Control")).toBe("no-store");
-    } finally {
-      Date.now = originalDateNow;
-    }
+        headers: new Headers(),
+      } as never,
+      { params: { jobId: "job-123" } }
+    );
+
+    expect(response.status).toBe(410);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "JOB_EXPIRED",
+        message: "Job output has expired",
+      },
+    });
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
   });
 
   it("returns 404 for a denied expired job", async () => {
@@ -646,5 +644,9 @@ describe("/api/jobs/[jobId]", () => {
       },
     });
     expect(findUnique).not.toHaveBeenCalled();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 });

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -27,6 +27,22 @@ describe("metrics module", () => {
       METRICS_ENABLED: "false",
       NODE_ENV: "test",
     };
+    jest.doMock(
+      "pino",
+      () => {
+        const instance = {
+          child: jest.fn(),
+          debug: jest.fn(),
+          error: jest.fn(),
+          info: jest.fn(),
+          warn: jest.fn(),
+        };
+        instance.child.mockReturnValue(instance);
+        const pino = jest.fn(() => instance);
+        return { __esModule: true, default: pino };
+      },
+      { virtual: true }
+    );
   });
 
   it("increments counters and renders prometheus text in memory mode", async () => {

--- a/tests/presigned-uploader-component.test.tsx
+++ b/tests/presigned-uploader-component.test.tsx
@@ -25,7 +25,7 @@ describe("PresignedUploader", () => {
     const file = createFile("report.pdf");
     let runtime:
       | {
-          onBatchComplete?: (completed: Array<{ etag: string; fileId: string; filename: string }>) => void;
+          onBatchComplete?: (completed: Array<{ etag: string; fileId: string; filename: string; objectKey: string }>) => void;
           onItemUpdate?: (item: UploadItem) => void;
         }
       | undefined;
@@ -40,6 +40,7 @@ describe("PresignedUploader", () => {
             etag: "etag-1",
             fileId: "file-1",
             filename: "report.pdf",
+            objectKey: "uploads/2026/04/report.pdf",
           },
         ]),
       };
@@ -76,6 +77,7 @@ describe("PresignedUploader", () => {
           etag: "etag-1",
           fileId: "file-1",
           filename: "report.pdf",
+          objectKey: "uploads/2026/04/report.pdf",
         },
       ]);
     });
@@ -156,6 +158,29 @@ describe("PresignedUploader", () => {
     expect(screen.getByText(/only pdf files can be uploaded/i)).toBeInTheDocument();
   });
 
+  it("accepts a pdf filename even when the browser omits the mime type", () => {
+    const file = new File(["pdf"], "mobile-export.pdf", {
+      lastModified: 602,
+      type: "",
+    });
+
+    mockStartPresignedUploads.mockImplementation(() => ({
+      cancel: jest.fn(),
+      promise: Promise.resolve([]),
+    }));
+
+    render(<PresignedUploader />);
+
+    fireEvent.change(screen.getByLabelText(/select pdfs/i), {
+      target: { files: [file] },
+    });
+
+    expect(mockStartPresignedUploads).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByText(/only pdf files can be uploaded/i)
+    ).not.toBeInTheDocument();
+  });
+
   it("rejects mixed selections instead of partially uploading them", () => {
     const validFile = createFile("valid.pdf");
     const invalidFile = new File(["text"], "notes.txt", {
@@ -171,6 +196,22 @@ describe("PresignedUploader", () => {
 
     expect(mockStartPresignedUploads).not.toHaveBeenCalled();
     expect(screen.getByText(/only pdf files can be uploaded/i)).toBeInTheDocument();
+  });
+
+  it("rejects multiple files when configured for single-file mode", () => {
+    const firstFile = createFile("first.pdf");
+    const secondFile = createFile("second.pdf");
+
+    render(<PresignedUploader allowMultiple={false} />);
+
+    fireEvent.change(screen.getByLabelText(/select pdf/i), {
+      target: { files: [firstFile, secondFile] },
+    });
+
+    expect(mockStartPresignedUploads).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/choose a single pdf file to continue/i)
+    ).toBeInTheDocument();
   });
 
   it("cancels tracked uploads on unmount", async () => {

--- a/tests/presigned-uploader-helper.test.ts
+++ b/tests/presigned-uploader-helper.test.ts
@@ -69,6 +69,7 @@ describe("startPresignedUploads", () => {
           headers: {
             "content-type": "application/pdf",
           },
+          objectKey: "uploads/report.pdf",
           uploadUrl: "https://example.test/upload",
         })
       )
@@ -103,6 +104,7 @@ describe("startPresignedUploads", () => {
         etag: "etag-123",
         fileId: "file-123",
         filename: "report.pdf",
+        objectKey: "uploads/report.pdf",
       },
     ]);
 
@@ -140,6 +142,7 @@ describe("startPresignedUploads", () => {
         jsonResponse({
           fileId: "file-retry",
           headers: {},
+          objectKey: "uploads/retry.pdf",
           uploadUrl: "https://example.test/upload",
         })
       )
@@ -195,6 +198,7 @@ describe("startPresignedUploads", () => {
       jsonResponse({
         fileId: "file-cancel",
         headers: {},
+        objectKey: "uploads/cancel.pdf",
         uploadUrl: "https://example.test/upload",
       })
     );
@@ -265,6 +269,7 @@ describe("startPresignedUploads", () => {
       jsonResponse({
         fileId: "file-presign-cancel",
         headers: {},
+        objectKey: "uploads/presign-cancel.pdf",
         uploadUrl: "https://example.test/upload",
       })
     );
@@ -290,6 +295,7 @@ describe("startPresignedUploads", () => {
         jsonResponse({
           fileId: "file-1",
           headers: {},
+          objectKey: "uploads/first.pdf",
           uploadUrl: "https://example.test/upload-1",
         })
       )
@@ -298,6 +304,7 @@ describe("startPresignedUploads", () => {
         jsonResponse({
           fileId: "file-2",
           headers: {},
+          objectKey: "uploads/second.pdf",
           uploadUrl: "https://example.test/upload-2",
         })
       )
@@ -331,11 +338,13 @@ describe("startPresignedUploads", () => {
         etag: "etag-1",
         fileId: "file-1",
         filename: "first.pdf",
+        objectKey: "uploads/first.pdf",
       },
       {
         etag: "etag-2",
         fileId: "file-2",
         filename: "second.pdf",
+        objectKey: "uploads/second.pdf",
       },
     ]);
 

--- a/tests/split-page.test.tsx
+++ b/tests/split-page.test.tsx
@@ -1,0 +1,193 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import SplitPdfPage from "@/app/(tools)/split/page";
+
+jest.mock("@/components/upload/PresignedUploader", () => ({
+  __esModule: true,
+  default: function MockUploader(props: {
+    onComplete?: (completed: Array<{
+      etag: string;
+      fileId: string;
+      filename: string;
+      objectKey: string;
+    }>) => void;
+  }) {
+    return (
+      <button
+        onClick={() =>
+          props.onComplete?.([
+            {
+              etag: "etag-1",
+              fileId: "file-1",
+              filename: "report.pdf",
+              objectKey: "uploads/2026/04/guest/report.pdf",
+            },
+          ])
+        }
+        type="button"
+      >
+        Mock upload complete
+      </button>
+    );
+  },
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve({
+    json: async () => body,
+    ok: status >= 200 && status < 300,
+    status,
+  });
+}
+
+describe("SplitPdfPage", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("keeps submit disabled until one PDF is uploaded and ranges are valid", () => {
+    render(<SplitPdfPage />);
+
+    const submit = screen.getByRole("button", { name: /start split job/i });
+    expect(submit).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /mock upload complete/i }));
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/page ranges/i), {
+      target: { value: "1-3,5" },
+    });
+
+    expect(submit).toBeEnabled();
+  });
+
+  it("shows inline validation for invalid ranges", async () => {
+    render(<SplitPdfPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /mock upload complete/i }));
+    fireEvent.change(screen.getByLabelText(/page ranges/i), {
+      target: { value: "3-1" },
+    });
+    fireEvent.blur(screen.getByLabelText(/page ranges/i));
+
+    expect(
+      await screen.findByText(/use page ranges like 1-3,5,8-10/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /start split job/i })).toBeDisabled();
+  });
+
+  it("creates a job, polls progress, and only shows download when done", async () => {
+    let statusCallCount = 0;
+
+    (global.fetch as jest.Mock).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url === "/api/jobs") {
+        return jsonResponse(
+          {
+            jobId: "job-123",
+            status: "pending",
+          },
+          201
+        );
+      }
+
+      if (url === "/api/jobs/job-123") {
+        statusCallCount += 1;
+        const payload =
+          statusCallCount === 1
+            ? { status: "pending" }
+            : statusCallCount === 2
+              ? { status: "processing" }
+              : {
+                  downloadUrl: "https://example.com/download",
+                  status: "done",
+                };
+
+        return jsonResponse(payload, 200);
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+
+    render(<SplitPdfPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /mock upload complete/i }));
+    fireEvent.change(screen.getByLabelText(/page ranges/i), {
+      target: { value: "1-3,5" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /start split job/i }));
+
+    expect(await screen.findByText(/watching job-123/i)).toBeInTheDocument();
+    expect(screen.getByText(/queued/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /download split pdf/i })
+    ).not.toBeInTheDocument();
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(await screen.findByText(/processing/i)).toBeInTheDocument();
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /download split pdf/i })
+      ).toHaveAttribute("href", "https://example.com/download");
+    });
+  });
+
+  it("surfaces failed job messaging", async () => {
+    (global.fetch as jest.Mock).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url === "/api/jobs") {
+        return jsonResponse(
+          {
+            jobId: "job-456",
+            status: "pending",
+          },
+          201
+        );
+      }
+
+      if (url === "/api/jobs/job-456") {
+        return jsonResponse(
+          {
+            errorMessage: "The requested ranges could not be processed.",
+            status: "failed",
+          },
+          200
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+
+    render(<SplitPdfPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /mock upload complete/i }));
+    fireEvent.change(screen.getByLabelText(/page ranges/i), {
+      target: { value: "1-3,5" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /start split job/i }));
+
+    expect(
+      await screen.findByText(/the requested ranges could not be processed/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /download split pdf/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/tools-page.test.tsx
+++ b/tests/tools-page.test.tsx
@@ -15,11 +15,11 @@ describe("ToolsPage", () => {
     expect(
       screen.getByRole("heading", { name: /pdf upload dashboard/i })
     ).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /open tool/i })).toHaveAttribute(
-      "href",
-      "/dashboard"
-    );
-    expect(screen.getAllByText(/coming soon/i)).toHaveLength(3);
+    expect(
+      screen.getByRole("heading", { name: /split pdf by ranges/i })
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: /open tool/i })).toHaveLength(2);
+    expect(screen.getAllByText(/coming soon/i)).toHaveLength(2);
   });
 
   it("filters tool cards client-side", () => {

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -7,6 +7,7 @@
     "jest.setup.ts",
     "tests/**/*.ts",
     "tests/**/*.tsx",
+    "src/**/*.d.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
     "scripts/**/*.ts"


### PR DESCRIPTION
Implements issue #127 by shipping the public Split PDF (ranges) tool flow.

What’s included:
- Added public tool route:
  - `src/app/(tools)/split/page.tsx`
- Added split tool client orchestration:
  - single-file PDF upload
  - ranges input with Zod validation
  - job creation
  - polling-driven queued / processing / done / failed UI
  - download CTA only on successful completion
- Added shared client API helper:
  - `src/lib/api/client.ts`
- Added shared split ranges validation:
  - `src/lib/splitPdfRanges.ts`
- Refactored uploader to support tool-specific usage:
  - single-file mode
  - configurable copy
  - uploaded `objectKey` handoff
  - filename-based `.pdf` fallback when browser MIME type is missing
- Added guest-aware job creation endpoint:
  - `src/app/api/jobs/route.ts`
- Hardened split job creation:
  - validates ownership of uploaded file
  - requires file to be `READY`
  - rejects non-PDF file objects
  - passes `inputKey` and `options.ranges` into the queue payload
- Extended the queue / worker stub path for split jobs:
  - `src/lib/queue.ts`
  - `src/server/jobs/processPdfJob.ts`
- Updated job projection so failed jobs can surface a safe error message:
  - `src/server/jobs/jobAccess.ts`
  - `src/types/job.ts`
- Updated tools hub so Split PDF is discoverable:
  - `src/app/(tools)/tools/page.tsx`

Tests added / updated:
- `tests/split-page.test.tsx`
- `tests/job-create-route.test.ts`
- `tests/presigned-uploader-component.test.tsx`
- `tests/presigned-uploader-helper.test.ts`
- `tests/tools-page.test.tsx`

Validation completed locally:
- `npm.cmd test`
- `npm.cmd run typecheck`
- `npm.cmd run lint`

Notes:
- The requested split ranges now survive the full client -> API -> queue -> worker path.
- The worker remains a stubbed PDF output path for now, so this PR delivers the production-ready UI/orchestration layer and correct backend contract, but not true page-range PDF splitting logic yet.
